### PR TITLE
Update tbl_sqlite_converter.bat

### DIFF
--- a/GBFRDataTools/Scripts/tbl_sqlite_converter.bat
+++ b/GBFRDataTools/Scripts/tbl_sqlite_converter.bat
@@ -3,7 +3,7 @@
 
 for %%i in (%*) do (
 	:: Must be updated to the current game version
-	set "version=1.3.1"
+	set "version=2.0.2"
 	if not exist "%~dp0table" (
 		mkdir "%~dp0Table"
 		@echo Generated Table folder.


### PR DESCRIPTION
GBFRDataTools `tbl_sqlite_converter` fails to convert `enemy_status.tbl` with the following error:
```ERROR: Failed to read table enemy_status - Table enemy_status did not match expected size, it's larger```
`tbl_sqlite_converter.bat` still hardcodes the game version to 1.3.1, causing .tbl to be parsed using the old table layout.
