### PR TITLE
Change database generated classes to records + header changes

### DIFF
--- a/GBFRDataTools.Database.Generator/Generator.cs
+++ b/GBFRDataTools.Database.Generator/Generator.cs
@@ -121,7 +121,7 @@ public class Generator : IIncrementalGenerator
 
         namespace GBFRDataTools.Database.Generated;
 
-        public class {{baseName.ToPascalCase()}}TableRow : IGameTableRow
+        public record {{baseName.ToPascalCase()}}TableRow : IGameTableRow
         {
             {{tcs.AsProperties().Indent(1)}}
 

--- a/GBFRDataTools.Database/Headers/constant.headers
+++ b/GBFRDataTools.Database/Headers/constant.headers
@@ -88,5 +88,5 @@ add_column|MaxLevelMSPReward|int
 add_column|MaxLevelRepeatXP|int
 add_column|Unk19|int
 add_column|Unk20|int
-add_column|Unk21|int
+add_column|MaxLevelTransmarvelReward|int
 reset_min_version|

--- a/GBFRDataTools.Database/Headers/enemy_exp.headers
+++ b/GBFRDataTools.Database/Headers/enemy_exp.headers
@@ -1,7 +1,7 @@
-add_column|Unk1|uint
-add_column|Unk2|uint
+add_column|MinGoldOnKill|uint
+add_column|MaxGoldOnKill|uint
 add_column|Key|hash_string
 add_column|ExpOnKill|uint
 add_column|Unk5|uint
-add_column|Unk6|uint
+add_column|MspOnKill|uint
 add_column|Unk7|uint

--- a/GBFRDataTools.Database/Headers/gem.headers
+++ b/GBFRDataTools.Database/Headers/gem.headers
@@ -97,7 +97,7 @@ add_column|ItemMaterialCommonAnimaSpecialBossColIndex|uint  // Fetched at: 48 83
 add_column|Category|uint                                    // cmn_icequ_{0:02}_{1:02} - higher than 3 will prompt before selling (high rarity treasure)
 add_column|Rarity|uint                                      // cmn_icequ_{0:02}_{1:02} <- minus 1
 add_column|ItemMaterialCommonStageColIndex|uint             // Fetched at: 48 83 C0 ? 44 8B 08 E9, Passed to: 41 57 41 56 41 55 41 54 56 57 55 53 48 83 EC ? 49 89 D7 49 89 CC 8B A9
-add_column|CanGemMix|byte
+add_column|CantGemMix|byte
 add_column|CantSell|byte
 add_column|HideLevelNumber|byte
 add_column|CanOnlyHoldOne|byte                              // Will disable getting duplicate awakenings

--- a/GBFRDataTools.Database/Headers/item_material_list.headers
+++ b/GBFRDataTools.Database/Headers/item_material_list.headers
@@ -40,5 +40,5 @@ add_column|ItemMaterialCommonBossCount2|int
 add_column|ItemMaterialCommonBossCount3|int
 add_column|ItemMaterialCommonStageCount1|int
 add_column|ItemMaterialCommonStageCount2|int
-add_column|Key|int
+add_column|Key|uint
 add_column|CoinCost|int

--- a/GBFRDataTools.Database/Headers/reward_summon.headers
+++ b/GBFRDataTools.Database/Headers/reward_summon.headers
@@ -1,5 +1,5 @@
 add_column|RewardId|hash_string
 add_column|RewardSummonLotId|hash_string
 add_column|LotChance|int
-add_column|Unk4|int
-add_column|Unk5|int
+add_column|MinAmountGiven|int
+add_column|MaxAmountGiven|int


### PR DESCRIPTION
While playing around with the generated code, I found that having `record` semantics on the table row to be more convenient and it allows the use of `with` instead of cloning + messing with the properties.

I also found some headers in `enemy_exp` and `gem` through experimenting, seems like `CanSell`, `CanGemMix` got inverted.

Also found the headers in `reward_summons`, but I am not sure on how to confirm them conclusively. Tested a few rounds of modifying `Unk4` and `Unk5`

- When `Unk4 == Unk5 == 10`, I got 10 summon drops
- When `Unk4 == 10 > Unk5`, I got 10 summon drops
- When `Unk4 == 1, Unk5 == 10`, I got 5 summon drops (assuming it would be random)

Also change the `Key`'s type in `item_material_list`, to be consistant with the type in `item_tier_map` (which I am assuming is an FK to it, searched the entire db and they seem to be linked to each other).